### PR TITLE
Don't panic if job has no properties

### DIFF
--- a/src/models/installer_arguments_test.go
+++ b/src/models/installer_arguments_test.go
@@ -32,7 +32,9 @@ var _ = Describe("InstallerArguments", func() {
 	Describe("NewInstallerArguments", func() {
 		It("errors when there are no rep jobs in the manifest", func() {
 			manifest := Manifest{
-				Jobs: []Job{},
+				Jobs: []Job{
+					Job{},
+				},
 			}
 			_, err := NewInstallerArguments(&manifest)
 			Expect(err).To(HaveOccurred())

--- a/src/models/models.go
+++ b/src/models/models.go
@@ -30,7 +30,7 @@ func (m *Manifest) FirstRepJob() (*Job, error) {
 	}
 
 	for _, job := range jobs {
-		if job.Properties.Diego != nil && job.Properties.Diego.Rep != nil {
+		if job.Properties != nil && job.Properties.Diego != nil && job.Properties.Diego.Rep != nil {
 			return &job, nil
 		}
 	}


### PR DESCRIPTION
We have a CF/Diego deployment manifest where we added a job with no job-properties section. When trying to deploy a Windows Cell, the `generate.exe` panic'ed. This fix will by-pass those jobs. 

For reference, this is the panic trace:

```
c:\tmp\dwminst>generate.exe -boshUrl=https://admin:REDACTED@REDACTED:25555 -outputDir=C:\tmp\dwminst
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x8 pc=0x57270e]

goroutine 1 [running]:
panic(0x6ecaa0, 0xc042004090)
        C:/go/src/runtime/panic.go:500 +0x1af
models.(*Manifest).FirstRepJob(0xc04205e3c0, 0xc0423a2000, 0x4c878, 0x4e000)
        C:/diego-windows-release/greenhouse-install-script-generator/src/models/
models.go:33 +0xae
models.NewInstallerArguments(0xc04205e3c0, 0x4c878, 0x4e000, 0x6e6580)
        C:/diego-windows-release/greenhouse-install-script-generator/src/models/
installer_arguments.go:35 +0x36
main.main()
        C:/diego-windows-release/greenhouse-install-script-generator/src/generat
e/generate.go:145 +0x36e
```

And this is a snippet of our deployment:

```yaml
jobs:
- instances: 1
  name: prometheus_exporter_z1
  networks:
  - name: cf1
    static_ips:
    - 10.2.5.21
  resource_pool: medium_z1
  templates:
  - name: consul_agent
    release: cf
  - name: firehose_exporter
    release: prometheus
  - name: cf_exporter
    release: prometheus
  - name: mysqld_exporter
    release: prometheus
  - name: toolbelt
    release: toolbelt
  - name: toolbelt-quick
    release: toolbelt
```